### PR TITLE
Small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ set(PostgreSQL_ADDITIONAL_SEARCH_PATHS "/usr/include/postgresql/9.4/server" "/us
 cmake_minimum_required(VERSION 2.8)
 project(web_game)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+if (CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
 include_directories(include)
 
@@ -32,7 +34,7 @@ if (MSVC)
 endif()
 
 #external libraries
-set(gtest_force_shared_crt ON CACHE BOOL "Use shared (DLL) run-time lib even when Google Test is built as static lib.")
+set(gtest_force_shared_crt ON CACHE BOOL "Use shared (DLL) run-time lib even when Google Test is built as static lib." FORCE)
 add_subdirectory(lib/gtest/googletest)
 include_directories(${gtest_SOURCE_DIR}/include)
 set(GTEST_LIBS
@@ -58,9 +60,9 @@ add_executable(runner
     src/AbstractRouter.cpp
     src/Router.cpp
     src/Pages.cpp
-	src/GameEngine.cpp
+    src/GameEngine.cpp
     src/Users.cpp
-	include/GameEngine.hpp
+    include/GameEngine.hpp
     include/DBConnector.hpp
     include/Router.hpp
     include/WebgameServer.hpp
@@ -70,8 +72,8 @@ target_link_libraries(runner ${POCO_LIBS} ${PostgreSQL_LIBRARIES})
 
 add_executable(tester
     src/AbstractRouter.cpp
-	src/GameEngine.cpp
-	tests/Engine/EngineTest1.cpp
+    src/GameEngine.cpp
+    tests/Engine/EngineTest1.cpp
     tests/test_1.cpp
     tests/DBConnector/test_1.cpp
     tests/Router/test_1.cpp

--- a/README.md
+++ b/README.md
@@ -6,15 +6,21 @@ Set environment variable WEBGAME_BIN_FOLDER as an absolute path to the applicati
 
 **Unix**
 
-For now:
+For shell session:
 
 `export WEBGAME_BIN_FOLDER="/home/user/web-game/bin"`
 
 Permanent:
 
-`echo 'export WEBGAME_BIN_FOLDER="/home/web-game/bin"' >> ~/.profile`
+`echo 'export WEBGAME_BIN_FOLDER="/home/user/web-game/bin"' >> ~/.profile`
 
 **Windows**
+
+For shell session:
+
+`set WEBGAME_BIN_FOLDER=D:/web-game/bin`
+
+Permanent:
 
 Control Panel -> User accounts -> Environment Variables -> Create
 

--- a/include/DBConnector.hpp
+++ b/include/DBConnector.hpp
@@ -268,8 +268,8 @@ public:
             throw ConnectionException(std::string("Failed to connect to database. Message: '") + PQerrorMessage(conn) + "'");
         }
 
-#if (_DEBUG)
-        cout << "Connected to DB" << endl;
+#if _DEBUG
+        std::cout << "Connected to DB" << std::endl;
 #endif
     }
 

--- a/include/GameEngine.hpp
+++ b/include/GameEngine.hpp
@@ -234,7 +234,7 @@ namespace GameEngine {
                     continue;
                 i.Step(planets);
 
-#if (_DEBUG)
+#if _DEBUG
                 const int MAX_X = 10000;
                 const int MAX_Y = 10000;
                 for (auto& i : ships) {
@@ -283,3 +283,4 @@ namespace GameEngine {
 };
 
 #endif
+


### PR DESCRIPTION
CMakeLists.txt:

Enormous output is produced when compiling using Visual Studio with -Wall (lots of warnings are even for the standart library!), and it causes Visual Studio to hang
So let it be by default (/W3)
Also -std=c11 makes sence only for GCC

set FORCE for gtest_force_shared_crt